### PR TITLE
Add OTel semantic error attributes

### DIFF
--- a/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+ErrorSemantics.swift
+++ b/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+ErrorSemantics.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift Distributed Tracing project
+// authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+extension SpanAttributes {
+    /// Error attributes.
+    ///
+    /// OpenTelemetry Spec: [Semantic Conventions for Exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.11.0/specification/trace/semantic_conventions/exceptions.md)
+    public var error: ErrorAttributes {
+        get {
+            .init(attributes: self)
+        }
+        set {
+            self = newValue.attributes
+        }
+    }
+}
+
+/// Error attributes.
+///
+/// OpenTelemetry Spec: [Semantic Conventions for Exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.11.0/specification/trace/semantic_conventions/exceptions.md)
+@dynamicMemberLookup
+public struct ErrorAttributes: SpanAttributeNamespace {
+    public var attributes: SpanAttributes
+
+    public init(attributes: SpanAttributes) {
+        self.attributes = attributes
+    }
+
+    public struct NestedSpanAttributes: NestedSpanAttributesProtocol {
+        public init() {}
+
+        /// The type of the error. E.g. `AuthenticationError`.
+        public var type: Key<String> { "exception.type" }
+
+        /// The error message. E.g. `Token expired`.
+        public var message: Key<String> { "exception.message" }
+
+        /// The stacktrace up to the error.
+        public var stacktrace: Key<String> { "exception.stacktrace" }
+
+        /// Whether the error "escaped" the span.
+        ///
+        /// E.g., if the operation inside a span throws an error to the outside it's considered escaped.
+        /// If, on the other hand, the error is being handled inside the span it didn't escape.
+        public var escaped: Key<Bool> { "exception.escaped" }
+    }
+}

--- a/Tests/TracingOpenTelemetrySemanticConventionsTests/ErrorSemanticsTests.swift
+++ b/Tests/TracingOpenTelemetrySemanticConventionsTests/ErrorSemanticsTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Distributed Tracing project
+// authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+@testable import TracingOpenTelemetrySemanticConventions
+import XCTest
+
+final class ErrorSemanticsTests: XCTestCase {
+    func test_error() {
+        var attributes = SpanAttributes()
+
+        attributes.error.type = "AuthenticationError"
+        attributes.error.message = "The provided token already expired."
+        attributes.error.stacktrace = "test"
+        attributes.error.escaped = true
+
+        XCTAssertSpanAttributesEqual(attributes, [
+            "exception.type": "AuthenticationError",
+            "exception.message": "The provided token already expired.",
+            "exception.stacktrace": "test",
+            "exception.escaped": true,
+        ])
+    }
+}


### PR DESCRIPTION
- Closes #5

This is based on #21 which should be merged first.