### PR TITLE
Explicitly call out otel in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,34 @@
+
+                         Swift Distributed Tracing
+                         =========================
+
+Please visit the Swift Distributed Tracing web site for more information:
+
+  * https://github.com/apple/swift-distributed-tracing
+
+Copyright 2020-2023 The Swift Distributed Tracing Project
+
+The Swift Distributed Tracing Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.<component>.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+
+This product contains references to and uses vocabulary defined by the Open Telemetry Specification
+
+  * LICENSE (Apache License 2.0):
+    * https://github.com/open-telemetry/opentelemetry-specification/blob/main/LICENSE
+  * HOMEPAGE:
+    * https://opentelemetry.io


### PR DESCRIPTION
The purpose of the otel support module is to provide well-typed keys for attributes defined by open telemetry. We should call this out explicitly, and also note the license is compatible with our own.