### PR TITLE
Update CI

### DIFF
--- a/docker/docker-compose.2004.58.yaml
+++ b/docker/docker-compose.2004.58.yaml
@@ -6,7 +6,8 @@ services:
     image: swift-distributed-tracing-extras:20.04-5.8
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.8-focal"
+        ubuntu_version: "focal"
+        swift_version: "5.8"
 
   test:
     image: swift-distributed-tracing-extras:20.04-5.8

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-distributed-tracing-extras:22.04-5.9
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.9-jammy"
+
+  test:
+    image: swift-distributed-tracing-extras:22.04-5.9
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-distributed-tracing-extras:22.04-5.9
+
+  docs:
+    image: swift-distributed-tracing-extras:22.04-5.9

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -3,18 +3,18 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-distributed-tracing-extras:22.04-5.8
+    image: swift-distributed-tracing-extras:22.04-main
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-jammy"
 
   test:
-    image: swift-distributed-tracing-extras:22.04-5.8
+    image: swift-distributed-tracing-extras:22.04-main
     environment: []
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:
-    image: swift-distributed-tracing-extras:22.04-5.8
+    image: swift-distributed-tracing-extras:22.04-main
 
   docs:
-    image: swift-distributed-tracing-extras:22.04-5.8
+    image: swift-distributed-tracing-extras:22.04-main


### PR DESCRIPTION
- Swift 5.8 docker images are available
- Add docker-compose file for Swift 5.9
- Fix image name for `main`