### PR TITLE
Fixed the link to otel semantic conventions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then, you can depend on the extras package:
 #### Usage
 
 The OpenTelemetry Semantic Conventions package provides span attributes to work with [OpenTelemetry's
-semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/trace/).
+semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.11.0/specification/trace/semantic_conventions).
 
 Semantic attributes enable users of [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing) to
 set attributes on spans using a type-safe pre-defined and well known attributes, like this:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then, you can depend on the extras package:
 #### Usage
 
 The OpenTelemetry Semantic Conventions package provides span attributes to work with [OpenTelemetry's
-semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/trace/).
 
 Semantic attributes enable users of [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing) to
 set attributes on spans using a type-safe pre-defined and well known attributes, like this:


### PR DESCRIPTION
The [original link 404s now](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions). They've moved the semantic conversions page out of the specification repo it seems, but there's a [nice doc on the website](https://opentelemetry.io/docs/specs/semconv/general/trace/) — so I've swapped the link to point to that.