### PR TITLE
Add Sendable annotations to structs that are clearly Sendable

### DIFF
--- a/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+FaaSSemantics.swift
+++ b/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+FaaSSemantics.swift
@@ -120,7 +120,7 @@ public struct FaaSAttributes: SpanAttributeNamespace {
 
         /// Well-known data operations,
         /// used for the ``FaaSAttributes/DocumentAttributes/NestedSpanAttributes/operation`` span attribute.
-        public struct Operation: RawRepresentable, SpanAttributeConvertible {
+        public struct Operation: RawRepresentable, SpanAttributeConvertible, Sendable {
             public let rawValue: String
 
             public init(rawValue: String) {
@@ -184,7 +184,7 @@ public struct FaaSAttributes: SpanAttributeNamespace {
 
 extension FaaSAttributes {
     /// Triggers which caused a function execution, used for the ``FaaSAttributes/NestedSpanAttributes/trigger`` span attribute.
-    public struct Trigger: RawRepresentable, SpanAttributeConvertible {
+    public struct Trigger: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {
@@ -218,7 +218,7 @@ extension FaaSAttributes {
 
 extension FaaSAttributes {
     /// Well-known cloud providers, used for the ``FaaSAttributes/NestedSpanAttributes/invokedProvider`` span attribute.
-    public struct Provider: RawRepresentable, SpanAttributeConvertible {
+    public struct Provider: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {

--- a/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+MessagingSemantics.swift
+++ b/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+MessagingSemantics.swift
@@ -231,7 +231,7 @@ public struct MessagingAttributes: SpanAttributeNamespace {
         }
 
         /// Possible values for the ``MessagingAttributes/RocketMQAttributes/NestedSpanAttributes/messageType`` span attribute.
-        public struct MessageType: RawRepresentable, SpanAttributeConvertible {
+        public struct MessageType: RawRepresentable, SpanAttributeConvertible, Sendable {
             public let rawValue: String
 
             public init(rawValue: String) {
@@ -256,7 +256,7 @@ public struct MessagingAttributes: SpanAttributeNamespace {
         }
 
         /// Possible values for the ``MessagingAttributes/RocketMQAttributes/NestedSpanAttributes/consumptionModel`` span attribute.
-        public struct ConsumptionModel: RawRepresentable, SpanAttributeConvertible {
+        public struct ConsumptionModel: RawRepresentable, SpanAttributeConvertible, Sendable {
             public let rawValue: String
 
             public init(rawValue: String) {
@@ -280,7 +280,7 @@ public struct MessagingAttributes: SpanAttributeNamespace {
 
 extension MessagingAttributes {
     /// Possible values for the ``MessagingAttributes/NestedSpanAttributes/destinationKind`` span attribute.
-    public struct DestinationKind: RawRepresentable, SpanAttributeConvertible {
+    public struct DestinationKind: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {
@@ -309,7 +309,7 @@ extension MessagingAttributes {
     /// as it can be inferred from the span kind.
     ///
     /// OpenTelemetry Spec: [Messaging Operation Names](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.11.0/specification/trace/semantic_conventions/messaging.md#operation-names)
-    public struct Operation: RawRepresentable, SpanAttributeConvertible {
+    public struct Operation: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {

--- a/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+NetworkSemantics.swift
+++ b/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+NetworkSemantics.swift
@@ -49,7 +49,7 @@ public struct NetworkAttributes: SpanAttributeNamespace {
     /// Possible values for the `network.transport` span attribute.
     ///
     /// OpenTelemetry Spec: [Network transport attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.11.0/specification/trace/semantic_conventions/span-general.md#network-transport-attributes)
-    public struct Transport: RawRepresentable, SpanAttributeConvertible {
+    public struct Transport: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {

--- a/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+RPCSemantics.swift
+++ b/Sources/TracingOpenTelemetrySemanticConventions/SpanAttributes+RPCSemantics.swift
@@ -150,7 +150,7 @@ public struct RPCAttributes: SpanAttributeNamespace {
             public var statusCode: Key<StatusCode> { "rpc.grpc.status_code" }
         }
 
-        public struct StatusCode: RawRepresentable, SpanAttributeConvertible {
+        public struct StatusCode: RawRepresentable, SpanAttributeConvertible, Sendable {
             public let rawValue: Int64
 
             public init(rawValue: Int64) {
@@ -271,7 +271,7 @@ public struct RPCAttributes: SpanAttributeNamespace {
 
 extension RPCAttributes {
     /// Well-known RPC systems, used for the ``RPCAttributes/NestedSpanAttributes/system`` span attribute.
-    public struct System: RawRepresentable, SpanAttributeConvertible {
+    public struct System: RawRepresentable, SpanAttributeConvertible, Sendable {
         public let rawValue: String
 
         public init(rawValue: String) {


### PR DESCRIPTION
While adopting Swift 6 language mode my team ran into some warnings from these types. But the types are clearly Sendable so it should be safe to add the annotations 