### PR TITLE
Enable strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,3 +36,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

- Enabled strict concurrency checking in Package.swift.

### Result:

Fewer potential data races can sneak in.

### Test Plan

Ran tests locally, did not see any concurrency warnings or errors.
